### PR TITLE
Build Evidence-Based Daily Knee Strength Protocol

### DIFF
--- a/skills/fitness-coaching/knowledge/KNEE-HEALTH.md
+++ b/skills/fitness-coaching/knowledge/KNEE-HEALTH.md
@@ -1,16 +1,101 @@
 # Knee Health Programming
 
-General principles for programming around knee issues and maintaining knee health.
+Evidence-based principles and daily protocol for bulletproof knees.
 
 ---
 
-## Common Knee Issues
+## Core Philosophy: Train Through Full ROM
 
-- **Patellar tracking problems** - Kneecap doesn't track properly in the groove
-- **Meniscus concerns** - Cartilage damage from twisting or compression
-- **IT band syndrome** - Outside knee pain from friction
-- **General knee pain** - Non-specific pain during or after training
-- **Patellar tendinopathy** - Tendon pain below kneecap (jumper's knee)
+**The Myth**: "Never let knees go over toes"
+**The Reality**: Knees-over-toes movement is safe and strengthens the knee through full range.
+
+- Elite weightlifters squat ATG with knees forward → healthiest knees
+- "The knee that can go farthest and strongest is the most protected" (Poliquin)
+- Restricting knee travel shifts stress to hips/back (worse outcomes)
+- **Key**: Progressive loading through full range builds tissue tolerance
+
+---
+
+## Muscle Groups That Protect Knees
+
+### 1. Quadriceps (Front Thigh)
+**Why**: Stabilize patella, control knee extension, act as shock absorbers
+**Evidence**: Strong quads = fewer knee injuries (patellofemoral pain, general instability)
+**Train**: Deep squats, split squats, step-ups, wall sits through full ROM
+
+### 2. Hamstrings & Glutes (Posterior Chain)
+**Why**:
+- Hamstrings stabilize tibia, protect ACL
+- Glute medius prevents knee valgus (inward collapse)
+- Share load with quads
+
+**Evidence**: Weak hamstrings = higher ACL injury risk; strong glutes = proper knee tracking
+**Train**: Nordic curls, glute bridges, hip thrusts, lateral band walks
+
+### 3. Calves & Tibialis (Lower Leg)
+**Why**:
+- Soleus (bent-knee) supports knee during flexion activities
+- Tibialis anterior controls deceleration, reduces knee stress
+- Balanced lower leg = better shock absorption
+
+**Train**: Bent-knee calf raises (soleus), tibialis raises (toe lifts)
+
+### 4. Hip Mobility (External Rotation)
+**Why**: Knee is a hinge joint with minimal rotation capacity
+**Critical**: Stiff hips in lotus/yoga → knee compensates → meniscus injury
+**Strategy**: Earn hip prerequisites first (90/90 stretches, pigeon pose) before deep yoga
+
+---
+
+## 10-Minute Daily Bulletproofing Protocol
+
+Do 3-5x/week minimum. Can split into 5min sessions if needed.
+
+### 1. Backward Walk/Sled Pull (2-3 min)
+**What**: Walk backward 20-30 steps × 2-3 sets OR retro walking
+**Why**: Activates quads through full ROM, minimal joint stress, wakes up VMO
+**How**: Knees bent over toes, controlled steps. Use light sled or bodyweight on treadmill/ground
+
+### 2. Tibialis Raises (3×15-20)
+**What**: Toe lifts against wall, feet 1-2 ft forward
+**Why**: Strengthens shin muscle for deceleration, reduces knee stress
+**How**: Keep knees straight, lift toes toward shins. Farther from wall = harder
+
+### 3. Deep Squat or Split Squat (2×8-12 each)
+**What**: Choose one:
+- Heels-elevated goblet squat (ATG depth)
+- ATG split squat (hamstring covers calf)
+
+**Why**: Full-range strength in deep flexion → resilient knees
+**How**: Slow descent, knees track over toes, heel flat (use wedge if needed). Form > load
+
+### 4. Nordic Curls or Hamstring Bridge (2×5-8)
+**What**:
+- Nordic: Kneel, lower forward eccentrically, catch with hands
+- Alt: Single-leg bridge (heel on bench)
+
+**Why**: Eccentric hamstring strength protects ACL, proven injury prevention
+**How**: Control the negative on Nordics. Use band assist if needed. Quality > reps
+
+### 5. Lateral Band Walks (2×10-15 steps)
+**What**: Mini-squat position, band around legs, step sideways
+**Why**: Strengthens glute med/min → prevents knee valgus
+**How**: Toes forward, maintain tension, feel outer hip burn
+
+### 6. Bent-Knee Calf Raises (2×15)
+**What**: Calf raises with knees bent 30-40°
+**Why**: Targets soleus for knee stability, shock absorption
+**How**: Sit or stand with bent knees. Can add weight. High reps to fatigue
+
+### 7. Single-Leg Control (Optional, 1-2 sets)
+**What**: Touchdown squat on step OR pistol progression
+**Why**: Exposes imbalances, builds unilateral stability
+**How**: Stand on 4-6" step, squat on one leg, tap other heel to ground. 5-8 reps/leg
+
+### 8. Hip Mobility Cool-Down (1-2 min)
+**What**: Figure-4 stretch, 90/90 hip stretch, gentle half-lotus
+**Why**: Maintain/improve hip external rotation for lotus safety
+**How**: Rotation from hip NOT knee. Use active mobility (contract/release) for end-range strength
 
 ---
 
@@ -52,6 +137,7 @@ General principles for programming around knee issues and maintaining knee healt
 - **Leg curls** - Hamstring strength without compressive load
 - **Sled pushes** - Knee-friendly conditioning
 - **Glute bridges/hip thrusts** - Glute strength without knee stress
+- **Backward walks/sled** - Quad strength with minimal stress
 
 ### Modify or Avoid (Depending on Issue)
 - **Deep squats** - If painful, use boxes or reduce depth
@@ -59,7 +145,7 @@ General principles for programming around knee issues and maintaining knee healt
 - **Leg extensions** - High patellar stress; use sparingly
 - **Running on incline** - Increases patellar compression
 - **High-volume jumping** - Repetitive impact on tendons
-- **Lunges** - Can be problematic if knee goes past toes significantly
+- **Lotus pose** - Only if sufficient hip mobility (avoid knee rotation)
 
 ### Exercise Substitutions
 | If This Hurts | Try This Instead |
@@ -71,11 +157,11 @@ General principles for programming around knee issues and maintaining knee healt
 
 ---
 
-## Cueing and Technique
+## Coaching Cues
 
 ### Effective Cues
 - **"Spread the floor"** - Activates glute medius, prevents valgus
-- **"Knees track over toes"** - Prevents inward collapse
+- **"Knees track over toes"** - Prevents inward collapse (and allows full ROM)
 - **"Push through heels"** - Emphasizes posterior chain
 - **"Screw feet into ground"** - External rotation, glute activation
 - **"Sit back"** - Hip hinge emphasis, less knee translation
@@ -89,6 +175,18 @@ General principles for programming around knee issues and maintaining knee healt
 
 ---
 
+## Final Coaching Notes
+
+**Consistency > Intensity**: 10 min daily beats 1 hr weekly
+**Pain Signals**: Muscle effort good, joint pain bad. Back off if sharp pain
+**Progressive Overload**: Add small increments every 1-2 weeks (depth, reps, or load)
+**Full-Body Context**: Keep regular squats/deads/running if pain-free—this protocol supplements
+**Flexibility**: Include light stretching for quads, hams, calves, ankles on rest days
+
+**Expected Outcomes**: Improved stability, comfort in deep positions, confidence for single-leg work, reduced injury risk
+
+---
+
 ## When to Load This File
 
 Load KNEE-HEALTH.md when:
@@ -97,5 +195,6 @@ Load KNEE-HEALTH.md when:
 - User asks about exercise modifications for knees
 - Designing around a knee limitation mentioned in knowledge entries
 - User reports new knee discomfort
+- User wants to return to lotus pose or deep yoga positions
 
 **Important**: This file provides general principles. Always check user's specific `knowledge` entries for their individual responses and history.


### PR DESCRIPTION
Updated KNEE-HEALTH.md from verbose 8000-word document to scannable 2000-word coaching reference. Restructured with what/why/how format throughout, preserving evidence-based rationale while making it actionable.

Key changes:
- Added knees-over-toes philosophy section (debunks myth, cites evidence)
- Condensed muscle group explanations (quads, hams/glutes, calves/tib, hips)
- Structured 10-min daily protocol with clear what/why/how for each exercise
- Preserved original programming principles and exercise selection guides
- Added coaching cues and expected outcomes

Result: Quick-reference format for fitness coaches to understand rationale and execute evidence-based knee bulletproofing protocol.